### PR TITLE
Simplify enum approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,23 +107,24 @@ This proposal introduces three new well-known symbols that are used with enums:
 
 ## Properties of the Number Constructor
 
-The Number constructor would have an additional @@toEnum method with parameters `key` and `value`
-that returns the value of `value`.
+The Number constructor would have an additional @@toEnum method with parameters `key` and 
+`autoValue` that returns the result of post-incrementing `autoValue.value` by `1`.
 
 ## Properties of the String Constructor
 
-The String constructor would have an additional @@toEnum method with parameters `key` and `value` 
-that returns a string derived from `key`.
+The String constructor would have an additional @@toEnum method with parameters `key` and 
+`autoValue` that returns a string derived from `key`.
 
 ## Properties of the Symbol Constructor
 
-The Symbol constructor would have an additional @@toEnum method that parameters `key` and `value`
-that returns a symbol whose description is derived from `key`.
+The Symbol constructor would have an additional @@toEnum method that parameters `key` and 
+`autoValue` that returns a symbol whose description is derived from `key`.
 
 ## Properties of the BigInt Constructor
 
-The BigInt constructor would have an additional @@toEnum method with parameters `key` and `value`
-that returns the value of `value` as a BigInt.
+The BigInt constructor would have an additional @@toEnum method with parameters `key` and 
+`autoValue` that returns result of post-incrementing `autoValue.value` (coerced to a 
+BigInt) by `1n`.
 
 ## Enum Declarations
 
@@ -178,17 +179,17 @@ Enum members consist of a comma-separated list of enum member names with optiona
   - A runtime error is necessary as computed property names must be evaluated.
 - Enum members may be decorated, and the decorator may modify or add new _enum members_, or 
   replace the default initializer.
-- When evaluating _enum members_, <var>autoValue</var> is initialized to 0. This variable is used
+- When evaluating _enum members_, <var>autoValue</var> is initialized to `{ value: 0 }`. This variable is used
   to manage auto-increment behavior.  
 - If an _enum member_ has an initializer:
   - The result of the initializer expression will be coerced via ToPrimitive (<var>memberName</var>).
   - The initializer can refer to other named members that have come before it in the same enclosing 
     lexical `enum` declaration.
-  - If the result of evaluating the initializer is an integer, store the result in <var>autoValue</var>.
+  - If the result of evaluating the initializer is a value that when coerced to an Object is an 
+    instance of <var>memberType</var>, store the result in <var>autoValue</var>.
 - When no initializer is specified:
   - The <var>enumMap</var> function is called with <var>memberType</var> as its receiver and the 
     arguments <var>memberName</var> and <var>autoValue</var>.
-  - <var>autoValue</var> is incremented by 1.
 
 Enum members are `[[Writable]]`: **false**, `[[Enumerable]]`: **false**, and `[[Configurable]]`: 
 **false**.

--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ As we evaluate each _enum member_, we perform the following steps:
 1. Add `key` to the List of member names in the \[\[EnumMembers]] internal slot of the 
   _enum object_.
 1. Define a new property on the _enum object_ with the name `key` and the value `value`,
-  and the attributes `[[Writable]]`: **false**, `[[Enumerable]]`: **false**, and 
-  `[[Configurable]]`: **false**.
+  and the attributes `[[Writable]]`: **false**, `[[Configurable]]`: **false**, and
+  `[[Enumerable]]`: **true**.
 
 In addition, the following additional properties are added to _enum objects_:
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,15 @@ This proposal introduces three new well-known symbols that are used with enums:
 ## Properties of the Number Constructor
 
 The Number constructor would have an additional @@toEnum method with parameters `key` and 
-`autoValue` that returns the result of post-incrementing `autoValue.value` by `1`.
+`autoValue` that performs the following steps:
+
+1. Let `value` be `autoValue.value`.
+1. If `value` is `undefined`, 
+  1. Set `autoValue.value` to be `1`.
+  1. Return `0`.
+1. Else,
+  1. Increment `autoValue.value` by `1`.
+  1. Return `value`.
 
 ## Properties of the String Constructor
 
@@ -123,8 +131,15 @@ The Symbol constructor would have an additional @@toEnum method that parameters 
 ## Properties of the BigInt Constructor
 
 The BigInt constructor would have an additional @@toEnum method with parameters `key` and 
-`autoValue` that returns result of post-incrementing `autoValue.value` (coerced to a 
-BigInt) by `1n`.
+`autoValue` that performs the following steps:
+
+1. Let `value` be `autoValue.value`.
+1. If `value` is `undefined`, 
+  1. Set `autoValue.value` to be `1n`.
+  1. Return `0n`.
+1. Else,
+  1. Increment `autoValue.value` by `1n`.
+  1. Return `value`.
 
 ## Enum Declarations
 
@@ -171,7 +186,7 @@ created:
 
 Enum members consist of a comma-separated list of enum member names with optional initializers:
 
-- _enum members_ are evaluated with a supplied <var>memberType</hint> object and <var>enumMap</var>
+- _enum members_ are evaluated with a supplied `memberType` object and `enumMap`
   function.
 - Enum names can be identifiers, string literals, or computed property names. When evaluated
   each name is coerced via ToPropertyKey.
@@ -179,17 +194,16 @@ Enum members consist of a comma-separated list of enum member names with optiona
   - A runtime error is necessary as computed property names must be evaluated.
 - Enum members may be decorated, and the decorator may modify or add new _enum members_, or 
   replace the default initializer.
-- When evaluating _enum members_, <var>autoValue</var> is initialized to `{ value: 0 }`. This variable is used
+- When evaluating _enum members_, `autoValue` is initialized to `{ value: undefined }`. This variable is used
   to manage auto-increment behavior.  
 - If an _enum member_ has an initializer:
-  - The result of the initializer expression will be coerced via ToPrimitive (<var>memberName</var>).
   - The initializer can refer to other named members that have come before it in the same enclosing 
     lexical `enum` declaration.
-  - If the result of evaluating the initializer is a value that when coerced to an Object is an 
-    instance of <var>memberType</var>, store the result in <var>autoValue</var>.
+  - The result of the initializer expression will be coerced via ToPrimitive (`memberValue`).
+  - If ToObject(`memberValue`) is an instance of `memberType`, store the result in `autoValue.value`.
 - When no initializer is specified:
-  - The <var>enumMap</var> function is called with <var>memberType</var> as its receiver and the 
-    arguments <var>memberName</var> and <var>autoValue</var>.
+  - The `enumMap` function is called with `memberType` as its receiver and the 
+    arguments `memberName` and `autoValue`.
 
 Enum members are `[[Writable]]`: **false**, `[[Enumerable]]`: **false**, and `[[Configurable]]`: 
 **false**.

--- a/README.md
+++ b/README.md
@@ -208,7 +208,9 @@ methods:
   and the enum member value at index 1.
 - `Enum.has(E, key)` - Returns `true` if the the \[\[EnumMembers]] internal slot of `E` contains `key`.
 - `Enum.hasValue(E, value)` - Returns `true` if the \[\[EnumMembers]] internal slot of `E` contains a
-  member whose value on `E` corresponds to`value`.
+  member whose value on `E` corresponds to `value`.
+- `Enum.getName(E, value)` - Gets the first name in the \[\[EnumMembers]] internal slot of `E` whose
+  value on `E` corresponds to `value`.
 - `Enum.format(E, value)` - Calls the @@formatEnum method of `E` with argument `value`.
 - `Enum.parse(E, value)` - Calls the @@parseEnum method of `E` with argument `value`.
 - `Enum.create(members)` - Creates an _enum object_ using the property keys and values of `members`
@@ -229,6 +231,7 @@ let Enum: {
   entries(E: object): IterableIterator<[string | symbol, any]>;
   has(E: object, key: string | symbol): boolean;
   hasValue(E: object, value: any): boolean;
+  getName(E: object, value: any): string | undefined;
   format(E: object, value: any): string | symbol | undefined;
   parse(E: object, value: string): any;
   create(members: object): object;
@@ -240,37 +243,6 @@ let Enum: {
 # Grammar
 
 ```grammarkdown
-EnumDeclaration[Yield, Await, Default] :
-  `enum` BindingIdentifier[?Yield, ?Await] EnumTail[?Yield, ?Await]
-  [+Default] `enum` EnumTail[?Yield, ?Await]
-
-EnumExpression[Yield, Await] :
-  `enum` BindingIdentifier[?Yield, ?Await]? EnumTail[?Yield, ?Await]
-
-EnumTail[Yield, Await] :
-  `{` EnumBody[?Yield, ?Await] `}`
-
-EnumBody[Yield, Await] :
-  EnumElementList[?Yield, ?Await]
-
-EnumElementList[Yield, Await] :
-  EnumElement[?Yield, ?Await]
-  EnumElementList[?Yield, ?Await] `,` EnumElement[?Yield, ?Await]
-
-EnumElement[Yield, Await] :
-  PropertyName[?Yield, ?Await] Initializer[+In, ?Yield, ?Await]?
-
-PrimaryExpression[Yield, Await] :
-  ...
-  EnumExpression[?Yield, ?Await]
-
-Declaration[Yield, Await] :
-  ...
-  EnumDeclaration[?Yield, ?Await]
-
-ExportDeclaration :
-  `export` `default` EnumDeclaration[~Yield, ~Await, +Default]
-  `export` `default` [lookahead ∉ { `function`, `async` [no LineTerminator here] `function`, `class`, `enum` }] AssignmentExpression[+In, ~Yield, ~Await];
 ```
 -->
 
@@ -331,11 +303,11 @@ enum AToB {
     b = "a",
 }
 
-Enum.parse(AToB, "a") === AToB.a // "b"
-Enum.parse(AToB, "b") === AToB.b // "a"
+Enum.parse(AToB, "a") === AToB.a
+Enum.parse(AToB, "b") === AToB.b
 
-Enum.format(AToB, AToB.a) === "b"
-Enum.format(AToB, AToB, b) === "a"
+Enum.getName(AToB, AToB.a) === "b"
+Enum.getName(AToB, AToB, b) === "a"
 
 // `Enum.create()` lets you create a new enum programmatically:
 const SyntaxKind = Enum.create({ 

--- a/README.md
+++ b/README.md
@@ -110,13 +110,9 @@ This proposal introduces three new well-known symbols that are used with enums:
 The Number constructor would have an additional @@toEnum method with parameters `key` and 
 `autoValue` that performs the following steps:
 
-1. Let `value` be `autoValue.value`.
-1. If `value` is `undefined`, 
-  1. Set `autoValue.value` to be `1`.
-  1. Return `0`.
-1. Else,
-  1. Increment `autoValue.value` by `1`.
-  1. Return `value`.
+1. If `autoValue.value` is `undefined`, set `autoValue.value` to `0`.
+1. Else, increment `autoValue.value` by `1`.
+1. Return `autoValue.value`.
 
 ## Properties of the String Constructor
 
@@ -133,13 +129,9 @@ The Symbol constructor would have an additional @@toEnum method that parameters 
 The BigInt constructor would have an additional @@toEnum method with parameters `key` and 
 `autoValue` that performs the following steps:
 
-1. Let `value` be `autoValue.value`.
-1. If `value` is `undefined`, 
-  1. Set `autoValue.value` to be `1n`.
-  1. Return `0n`.
-1. Else,
-  1. Increment `autoValue.value` by `1n`.
-  1. Return `value`.
+1. If `autoValue.value` is `undefined`, set `autoValue.value` to `0n`.
+1. Else, increment `autoValue.value` by `1n`.
+1. Return `autoValue.value`.
 
 ## Enum Declarations
 

--- a/enum.grammar
+++ b/enum.grammar
@@ -1,0 +1,42 @@
+// A.2 - Expressions
+
+EnumExpression[Yield, Await] :
+  DecoratorList[?Yield, ?Await]? `enum` BindingIdentifier[?Yield, ?Await]? EnumTail[?Yield, ?Await]
+
+PrimaryExpression[Yield, Await] :
+  <ins>EnumExpression[?Yield, ?Await]</ins>
+
+
+// A.3 - Statements
+
+EnumDeclaration[Yield, Await, Default, Decorators] :
+  `enum` BindingIdentifier[?Yield, ?Await] EnumTail[?Yield, ?Await]
+  [+Default] `enum` EnumTail[?Yield, ?Await]
+  [+Decorators] DecoratorList[?Yield, ?Await] `enum` BindingIdentifier[?Yield, ?Await] EnumTail[?Yield, ?Await]
+
+EnumTail[Yield, Await] :
+  EnumHeritage[?Yield, ?Await]? `{` EnumBody[?Yield, ?Await] `}`
+
+EnumHeritage[Yield, Await] :
+  `extends` LeftHandSideExpression[?Yield, ?Await]
+
+EnumBody[Yield, Await] :
+  EnumElementList[?Yield, ?Await]
+
+EnumElementList[Yield, Await] :
+  EnumElement[?Yield, ?Await]
+  EnumElementList[?Yield, ?Await] `,` EnumElement[?Yield, ?Await]
+
+EnumElement[Yield, Await] :
+  DecoratorList[?Yield, ?Await]? PropertyName[?Yield, ?Await] Initializer[+In, ?Yield, ?Await]?
+
+Declaration[Yield, Await, Decorators] :
+  <ins>EnumDeclaration[?Yield, ?Await, ?Decorators]</ins>
+
+
+// A.5 - Scripts and Modules
+
+ExportDeclaration :
+  <ins>DecoratorList[~Yield, ~Await] `export` EnumDeclaration[~Yield, ~Await, +Default, ~Decorators]</ins>
+  <ins>DecoratorList[~Yield, ~Await]? `export` `default` EnumDeclaration[~Yield, ~Await, +Default, ~Decorators]</ins>
+  `export` `default` [lookahead ∉ { `function`, `async` [no LineTerminator here] `function`, `class`, `@`, <ins>`enum`</ins> }] AssignmentExpression[+In, ~Yield, ~Await] `;`


### PR DESCRIPTION
Based on the conversation in #1, this simplifies the design of `enum` to avoid a new primitive, but allows declarations to be more flexible by specifying an optional _EnumHeritage_ clause that modifies the runtime behavior to more easily support enums whose member values are Strings or Symbols.