### PR TITLE
Rework into MVP `enum` proposal

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ popular and heavily used feature of TypeScript, this proposal seeks the adoption
 knowledge of the TypeScript development team and represents either a change that TypeScript is willing to adopt, or
 represents a limited subset of functionality that TypeScript expands upon.
 
-> NOTE: This proposal has been heavily reworked from it's prior incarnation, which can now be found at
+> NOTE: This proposal has been heavily reworked from its prior incarnation, which can now be found at
 > https://github.com/rbuckton/proposal-enum/tree/old
 
 ## Status

--- a/README.md
+++ b/README.md
@@ -240,10 +240,13 @@ enum Numbers {
 }
 ```
 
-However, this behavior is contentious amongst some TC39 delegates and has been removed from this proposal. TypeScript
-will continue to support auto-initialization due to its frequent use within the developer community, but would emit
-explicit initializers to JavaScript. It is possible that another form of auto-initialization may be introduced in the
-future that could be utilized by both TypeScript and ECMAScript. For more information, please refer to the
+However, this behavior is contentious amongst some TC39 delegates and has been removed from this proposal. The main
+concern that has been raised is that introducing new auto-initialized enum members in the middle of an existing enum
+has the potential to be a versioning issue in packages, and that such behavior should be harder to reach for, as opposed
+to being the default behavior. However, even if this capability is not supported, TypeScript will continue to support
+auto-initialization due to its frequent use within the developer community, but would emit explicit initializers to
+JavaScript. It is possible that another form of auto-initialization may be introduced in the future that could be
+utilized by both TypeScript and ECMAScript. For more information, please refer to the 
 [Auto-Initializers](#auto-initializers-1) topic in the [Future Directions](#future-directions) section.
 
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ enum Named {
 let x = Numbers.three;
 let y = Named["string name"];
 
-// Reverse mapping (formatting, debugging, diagnostics, etc):
+// Iteration, replaces TypeScript enum "Reverse mapping" (formatting, debugging, diagnostics, etc):
 for (const [key, value] of Numbers) ...
 ```
 
@@ -193,7 +193,7 @@ let E = (() => {
   Object.defineProperty(E, Symbol.toStringTag, { value: "E" });
   Object.preventExtensions(E);
   return E;
-})
+})();
 ```
 
 # Other Considerations
@@ -241,9 +241,11 @@ enum Numbers {
 ```
 
 However, this behavior is contentious amongst some TC39 delegates and has been removed from this proposal. TypeScript
-will continue to support auto-initializiation due to its frequent use within the developer community, but would emit
-explicit initializers to JavaScript. It is possible that another form of auto-initializiation may be introduced in the
-future that could be utilized by both TypeScript and ECMAScript.
+will continue to support auto-initialization due to its frequent use within the developer community, but would emit
+explicit initializers to JavaScript. It is possible that another form of auto-initialization may be introduced in the
+future that could be utilized by both TypeScript and ECMAScript. For more information, please refer to the
+[Auto-Initializers](#auto-initializers-1) topic in the [Future Directions](#future-directions) section.
+
 
 ## Declaration Merging
 
@@ -259,8 +261,8 @@ TypeScript currently supports reverse-mapping enum values back to enum member na
 overwrite other members. While this information is invaluable for debugging, diagnostics, formatting, and serialization,
 it is far less frequently used compared to `enum` on the whole.
 
-To avoid this inconsistency, we propose instead propose introducing reverse mapping by way of the `@@iterator` built-in
-symbol:
+To avoid this inconsistency, we instead propose using iteration (by way of the `@@iterator` built-in
+symbol) to cover the "reverse mapping" case:
 
 ```js
 enum E {
@@ -275,6 +277,9 @@ for (const [key, value] of E) {
 // prints:
 //  A: 0
 //  B: A
+
+const keyForA = E[Symbol.iterator]().find(([, value]) => value === "A")[0]
+console.log(keyForA); // prints: B
 ```
 
 If adopted, TypeScript would add support for `@@iterator` while eventually deprecating existing reverse mapping support.
@@ -283,8 +288,10 @@ If adopted, TypeScript would add support for `@@iterator` while eventually depre
 ## `const enum`
 
 TypeScript supports the concept of a `const enum` declaration, which is similar to a normal `enum` declaration except
-that enum values are inlined into their use sites. As this capability requires whole program knowledge, it is not a
-feature we intend to support in ECMAScript enums.
+that enum values are inlined into their use sites. Implementations are free to optimize as they see fit, and it's
+entirely reasonable that an implementation may eventually support similar inlining on a normal `enum` declaration. As
+the current `const enum` requires whole program knowlege and a type system, we believe it should remain a
+TypeScript-specific capability at this time.
 
 
 ## `Symbol` values

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Proposal for ECMAScript enums
 
-A common and oft-used feature of many languages is the concept of an 
-[Enumerated Type](https://en.wikipedia.org/wiki/Enumerated_type), or `enum`. Enums provide a finite
-domain of constant values that are regularly used to indicate choices, discriminants, and bitwise
-flags.
+A common and oft-used feature of many languages is the concept of an [Enumerated Type][], or `enum`. Enums provide a
+finite domain of constant values that are regularly used to indicate choices, discriminants, and bitwise flags. As a
+popular and heavily used feature of TypeScript, this proposal seeks the adoption of a compatible form of TypeScript's
+`enum` declaration. Where the syntax or semantics of this proposal differ from that of TypeScript, it is with the full
+knowledge of the TypeScript development team and represents either a change that TypeScript is willing to adopt, or
+represents a limited subset of functionality that TypeScript expands upon.
 
-* [Stage 0 Presentation](https://docs.google.com/presentation/d/1QQeogZ_GqCacKytUA7JMSZmiR5s2Cr4P8KGjGYzzHw0/edit?usp=sharing)
+> NOTE: This proposal has been heavily reworked from it's prior incarnation, which can now be found at
+> https://github.com/rbuckton/proposal-enum/tree/old
 
 ## Status
 
@@ -40,364 +43,346 @@ some kind of discriminant:
   - `os.platform()` (`"win32"`, `"linux"`, `"darwin"`, etc.)
   - `"constants"` module (`ENOENT`, `EEXIST`, etc.; `S_IFMT`, `S_IFREG`, etc.)
 
+In addition, with the recent adoption of [TypeScript Type Stripping][] in NodeJS, there has been renewed interest in
+ECMA-262 adopting a compatible form of TypeScript's `enum` declaration as it is one of the most frequently used
+TypeScript features not supported in this mode.
+
+An `enum` declaration provides several advantages over an object literal:
+- Closed domain by default &mdash; The declaration is non-extensible and enum members would be non-configurable
+  and non-writable.
+- Restricted domain of allowed values &mdash; Restricts initializers to a subset of allowed JS values (`Number`, 
+  `String`, `Symbol`, `BigInt`).
+- Self-references during definition &mdash; Referring to prior enum members of the same enum in the initializer of a
+  subsequent enum member.
+- Static Typing (tooling) &mdash; Static type systems like TypeScript use enum declarations to discriminate types,
+  provide documentation in hovers, etc.
+- ADT (future) &mdash; Potential future support for Algebraic Data Types.
+- Decorators (future) &mdash; Potential future support for `enum`-specific Decorators.
+- Auto-Initializers (future) &mdash; Potential future support for auto-initialized enum members.
+- "shared" enums (future) &mdash; Potential future support for a `shared enum` with restrictions on inputs to align with
+  [`shared struct`](https://github.com/tc39/proposal-structs)
+
 
 # Prior Art
 
+- TypeScript: [Enums](https://www.typescriptlang.org/docs/handbook/enums.html)  
 - C++: [Enumerations](https://docs.microsoft.com/en-us/cpp/cpp/enumerations-cpp)  
 - C#: [Enumeration types](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/enum)  
 - Java: [Enum types](https://docs.oracle.com/javase/specs/jls/se10/html/jls-8.html#jls-8.9)  
-- TypeScript: [Enums](https://www.typescriptlang.org/docs/handbook/enums.html)  
 
 
 # Syntax
 
+While a Stage 1 proposal is generally encouraged to avoid specific syntax, it is a stated goal of this proposal to
+introduce an `enum` declaration whose syntax is compatible with TypeScript's. As such, the syntax of this proposal is
+restricted to a subset of TypeScript's `enum`.
+
 ```ts
 // enum declarations
 
-// Each auto-initialized member value is a `Number`, auto-increments values by 1 starting at 0
 enum Numbers {
-  zero,
-  one,
-  two,
-  three,
-  alsoThree = three
+  zero = 0,
+  one = 1,
+  two = 2,
+  three = 3,
+  alsoThree = three // self reference
 }
 
-// Each auto-initialized member value is a `Number`, auto-increments values by 1 starting at 0
-enum Colors of Number {
-  red,
-  green,
-  blue
+enum PlayState {
+  idle = "idle",
+  running = "running",
+  paused = "paused"
 }
 
-// Each auto-initialized member value is a `String` whose value is the SV of its member name.
-enum PlayState of String {
-  idle,
-  running,
-  paused
-}
-
-// Each auto-initialized member value is a `Symbol` whose description is the SV of its member name.
-enum Symbols of Symbol {
-  alpha,
-  beta
+enum Symbols {
+  alpha = Symbol("alpha"),
+  beta = Symbol("beta") 
 }
 
 enum Named {
-  identifierName,
-  "string name",
-  [expr]
+  Identifier = 0,
+  "string name" = 1,
 }
 
 // Accessing enum values:
-let x = Color.red;
+let x = Numbers.three;
 let y = Named["string name"];
+
+// Reverse mapping (formatting, debugging, diagnostics, etc):
+for (const [key, value] of Numbers) ...
 ```
 
 # Semantics
 
-## Well-Known Symbols
+While a Stage 1 proposal is generally encouraged to avoid specific semantics, it is a stated goal of this proposal to
+introduce an `enum` declaration whose semantics are compatible with TypeScript's. As such, the semantics of this
+proposal are intended to align with that of TypeScript's `enum` where possible.
 
-This proposal introduces three new well-known symbols that are used with enums:
-
-| Specification Name | \[\[Description]] | Value and Purpose |
-|:-|:-|:-|
-| @@toEnum | `"Symbol.toEnum"` | A method that is used to derive the value for an enum member during _EnumMember_ evaluation. |
-| @@formatEnum | `"Symbol.formatEnum"` | A method of an _enum object_ that is used to convert a value into a string representation based on the member names of the enum. Called by `Enum.format`. |
-| @@parseEnum | `"Symbol.parseEnum"` | A method of an _enum object_ that is used to convert a member name String into the value represented by that member of the enum. Called by `Enum.parse`. |
 
 ## Enum Declarations
 
 Enum declarations consist of a finite set of _enum members_ that define the names and values
 for each member of the enum. These results are stored as properties of an _enum object_. An 
-_enum object_ is an ordinary object with an \[\[EnumMembers]] internal slot, and whose 
-\[\[Prototype]] is `null`.
+_enum object_ is an ordinary object whose \[\[Prototype]] is `null`. Each enum member defines
+a property on the _enum object_.
 
-### Automatic Initialization
+In addition, an _enum object_ contains an `@@iterator` method that yields a `[key, value]` entry for each declard enum
+member, in document order. To explain the semantics of the `@@iterator` method, an _enum object_ may require an
+\[\[EnumMembers]] internal slot.
 
-If an _enum member_ does not supply an _Initializer_, the value of that _enum member_ will be 
-automatically initialized:
 
-```js
-enum DaysOfTheWeek {
-  Sunday, // 0
-  Monday, // 1
-  Tuesday, // 2
-  // etc.
-}
-```
+## Enum Members
 
-Auto-initialization can be controlled through the use of an `of` clause:
+Enum members define the set of values that belong to the enum's domain. Each enum member consists of a name and an
+initializer that defines the value associated with that name. Enum members are \[\[Writable]]: `false` and
+\[\[Configurable]]: `false`.
 
-```js
-enum DaysOfTheWeek of Symbol {
-  Sunday, // Symbol("Sunday")
-  Monday, // Symbol("Monday")
-  Tuesday, // Symbol("Tuesday")
-  // etc.
-}
-```
 
-Constructors for built-in primitive values like `String`, `Number`, `Symbol`, and `BigInt` are 
-defined to have a `@@toEnum` method that is used during evaluation to select an 
-auto-initialization value. If the expression in the `of` clause does not have a `@@toEnum` method,
-it will instead be called directly. This allows constructors for built-ins to be used in the `of`
-clause without adding a niche constructor overload. This also allows developers to control the 
-behavior of `of` if its expression is an ECMAScript `class` which cannot be called directly.
+### Enum Member Names
 
-### Evaluation
+Enum member names are currently restricted to _IdentifierName_ and _StringLiteral_, as those are the only member names
+currently supported by TypeScript's `enum`. We may opt to expand this to allow other member names like
+_ComputedPropertyName_ in the future, if there is sufficient motivation.
 
-Before we evaluate the _enum members_ of the declaration, we first choose a `mapper` Object. 
-If the enum declaration has an `of` clause, the `mapper` is the result of evaluating that clause.
-Otherwise, `mapper` uses the default value of %Number%.
+An enum may not have duplicate member names. We may opt to introduce restrictions on member names like `constructor` if
+we deem it necessary to support ADT enums in the future.
 
-From the `mapper` we then get an `enumMap` function from `mapper[@@toEnum]`. If `enumMap` is
-`undefined`, then we set `enumMap` to `mapper` and `mapper` to `undefined`.
+ If an enum member name shares the same string value as the name of the enum itself, it shadows the enum declaration
+ name within the enum body.
 
-To support auto-initialization we also define two variables (both initialized to `undefined`): 
-- `value`: Stores the result of the last explicit or automatic initialization.
-- `autoValue`: Stores the result of the last automatic initialization only.
+### Enum Member Initializers
 
-As we evaluate each _enum member_, we perform the following steps:
+An enum member's initializer is restricted to a subset of
+ECMAScript values (i.e., `Number`, `String`, `Symbol`, and `BigInt`). This limitation allows us to consider future
+support for Algebraic Data Types (ADT) in enums without the possibility of conflicting with something like an enum
+member whose value is a function.
 
-1. Derive `key` from the _enum member_'s name.
-1. If the _enum member_ has an _Initializer_, then
-    1. Set `value` to be the result of evaluating _Initializer_.
-1. Else,
-    1. Set `autoValue` to be ? Call(`enumMap`, `mapper`, &laquo; `key`, `value`, `autoValue` &raquo;)
-    1. Set `value` to be `autoValue`
-1. Add `key` to the List of member names in the \[\[EnumMembers]] internal slot of the 
-  _enum object_.
-1. Define a new property on the _enum object_ with the name `key` and the value `value`,
-  and the attributes `[[Writable]]`: **false**, `[[Configurable]]`: **false**, and
-  `[[Enumerable]]`: **true**.
-
-In addition, the following additional properties are added to _enum objects_:
-
-  - A `@@parseEnum` property whose value is a Function that returns the value of the _enum member_ 
-    whose name corresponds to the provided argument. 
-    - This member is \[\[Writable]]: `false`, \[\[Configurable]]: `true`, and 
-      \[\[Enumerable]]: `false`.
-  - A `@@formatEnum` property whose value is a Function that returns the name of the first 
-    _enum member_ whose value corresponds to the provided argument.
-    - This member is \[\[Writable]]: `false`, \[\[Configurable]]: `true`, and 
-      \[\[Enumerable]]: `false`.
-  - A `@@toStringTag` property whose value is `"Enum"`.
-    - This member is \[\[Writable]]: `false`, \[\[Configurable]]: `true`, and 
-      \[\[Enumerable]]: `false`.
-  - An `@@iterator` property whose value is a Function that returns an iterator for this enum's 
-    \[\[EnumMembers]] internal slot where each yielded value is a two-element array containing the 
-    enum member name at index 0 and the enum member value at index 1.
-    - This member is \[\[Writable]]: `false`, \[\[Configurable]]: `true`, and 
-      \[\[Enumerable]]: `false`.
-  
-Finally, the _enum object_ is made non-extensible.
-
-## Properties of the Number Constructor
-
-The Number constructor would have an additional `@@toEnum` method with parameters `key`, `value`, 
-and `autoValue` that performs the following steps:
-
-1. If Type(`value`) is not Number, set `value` to `autoValue`.
-1. If `value` is `undefined`, return `0`.
-1. Otherwise, return `value + 1`.
-
-## Properties of the String Constructor
-
-The String constructor would have an additional `@@toEnum` method with parameters `key`, `value`,
-and `autoValue` that performs the following steps:
-
-1. Let `propKey` be ToPropertyKey(`key`).
-1. If Type(`propKey`) is Symbol, return `propKey`.\[\[Description]].
-1. Otherwise, return `propKey`.
-
-## Properties of the Symbol Constructor
-
-The Symbol constructor would have an additional `@@toEnum` method that parameters `key`, `value`,
-and `autoValue` that performs the following steps:
-
-1. Let `propKey` be ToPropertyKey(`key`).
-1. If Type(`propKey`) is Symbol, let `description` be `propKey`.\[\[Description]].
-1. Otherwise, let `description` be `propKey`.
-1. Return a new unique Symbol whose \[\[Description]] value is `description`.
-
-## Properties of the BigInt Constructor
-
-The BigInt constructor would have an additional `@@toEnum` method with parameters `key`, `value`,
-and `autoValue` that performs the following steps:
-
-1. If Type(`value`) is not BigInt, set `value` to `autoValue`.
-1. If `value` is `undefined`, return `0n`.
-1. Otherwise, return `value + 1n`.
+An _IdentifierReference_ in an enum member initializer may refer to the name of a prior declaration, and to the enum
+itself (much like a `class`).
 
 # API
 
-To make it easier to work with enums, an `Enum` object is added to the global scope, with the following
-methods:
+Aside from the `enum` declaration itself, there is no other proposed API.
 
-- `Enum.keys(E)` - Returns an `Iterator` for the member names in the \[\[EnumMembers]] internal 
-  slot of `E`.
-- `Enum.values(E)` - Returns an `Iterator` for the value on `E` of each member in the 
-  \[\[EnumMembers]] internal slot of `E`.
-- `Enum.entries(E)` - Returns an `Iterator` for each member in the \[\[EnumMembers]] internal
-  slot of `E`, where each result is two-element array containing the enum member name at index 0 
-  and the enum member value at index 1.
-- `Enum.has(E, key)` - Returns `true` if the the \[\[EnumMembers]] internal slot of `E` contains `key`.
-- `Enum.hasValue(E, value)` - Returns `true` if the \[\[EnumMembers]] internal slot of `E` contains a
-  member whose value on `E` corresponds to `value`.
-- `Enum.getName(E, value)` - Gets the first name in the \[\[EnumMembers]] internal slot of `E` whose
-  value on `E` corresponds to `value`.
-- `Enum.format(E, value)` - Calls the `@@formatEnum` method of `E` with argument `value`.
-- `Enum.parse(E, value)` - Calls the `@@parseEnum` method of `E` with argument `value`.
-- `Enum.create(members)` - Creates an _enum object_ using the property keys and values of `members`
-  as the _enum members_ for the new enum.
-- `Enum.flags(descriptor)` - A built-in decorator that modifies the _enum object_ in the following ways:
-  - The auto-increment behavior is changed to shift the current auto-increment value left by 1. 
-  - The `@@parseEnum` method is modified to parse a comma-separated string and OR the resulting values
-    together. If no corresponding name can be found and the name can be successfully coerced to a number,
-    that number is OR'ed with the result.
-  - The `@@formatEnum` method is modified to convert a bitwise combination of flag values into a comma
-    separated string of corresponding names. If no corresponding name can be found, the SV of the 
-    bits is appended to the string.
+An `enum` declaration will have an `@@iterator` method that can be used to iterate over the key/value pairs of the enum's
+members.
 
-```ts
-let Enum: {
-  keys(E: object): IterableIterator<string | symbol>;
-  values(E: object): IterableIterator<any>;
-  entries(E: object): IterableIterator<[string | symbol, any]>;
-  has(E: object, key: string | symbol): boolean;
-  hasValue(E: object, value: any): boolean;
-  getName(E: object, value: any): string | undefined;
-  format(E: object, value: any): string | symbol | undefined;
-  parse(E: object, value: string): any;
-  create(members: object): object;
-  flags(descriptor: EnumDescriptor): EnumDescriptor;
-};
-```
+# Desugaring
 
-<!--
-# Grammar
-
-```grammarkdown
-```
--->
-
-# Examples
-
-<!-- Examples of the proposal -->
+An `enum` declaration could potentially be implemented as the following desugaring:
 
 ```js
-enum Numbers { zero, one, two, three, }
-
-typeof Numbers.zero === "number"
-Numbers.zero === 0
-Enum.getName(Numbers, 0) === "zero"
-Enum.parse(Numbers, "zero") === 0
-
-// ... strings, ...
-enum HttpMethods of String { GET, PUT, POST, DELETE }
-
-typeof HttpMethods.GET === "string"
-HttpMethods.GET === "GET"
-
-// ... booleans, ...
-enum Switch { on = true, off = false }
-
-typeof Switch.on === "boolean";
-Switch.on === true
-
-// ... symbols, ...
-enum AlphaBeta of Symbol { alpha, beta }
-
-typeof AlphaBeta.alpha === "symbol";
-AlphaBeta.alpha.toString() === "Symbol(AlphaBeta.alpha)";
-
-// ... or a mix.
-enum Mixed {
-    number = 0,
-    string = "",
-    boolean = false,
-    symbol = Symbol()
+enum E {
+  A = 1,
+  B = 2,
+  C = A | E.B,
 }
 
-// Enums can be exported:
-export enum Zoo { lion, tiger, bear };
-export default enum { up, down, left, right };
-
-// You can test for name membership using `Enum.has()`
-Enum.has(Numbers, "one") === true
-Enum.has(Numbers, "five") === false
-
-// You can test for value membership using `Enum.hasValue()`:
-Enum.hasValue(Numbers, 0) === true
-Enum.hasValue(Numbers, 9) === false
-
-// You can convert enums between names and values using 
-// `Enum.parse` and `Enum.format`, respectively.
-enum AToB {
-    a = "b",
-    b = "a",
-}
-
-Enum.parse(AToB, "a") === AToB.a
-Enum.parse(AToB, "b") === AToB.b
-
-Enum.getName(AToB, AToB.a) === "b"
-Enum.getName(AToB, AToB, b) === "a"
-
-// `Enum.create()` lets you create a new enum programmatically:
-const SyntaxKind = Enum.create({ 
-  identifier: 0, 
-  number: 1, 
-  string: 2 
-});
-
-typeof SyntaxKind.identifier === "number";
-SyntaxKind.identifier === 0;
-
-
-// The `Enum.flags` decorator lets you declare a enum containing 
-// bitwise flag values:
-@Enum.flags
-enum FileMode {
-  none
-  read,
-  write,
-  exclusive,
-  readWrite = read | write,
-}
-
-FileMode.none === 0x0
-FileMode.readOnly === 0x1
-FileMode.readWrite === 0x3
-
-// `Enum.flags` modifies @@formatEnum:
-Enum.format(FileMode, FileMode.readWrite | FileMode.exclusive) === "readWrite, exclusive"
-
-// `EnumFlags` modifies @@parseEnum:
-Enum.parse(FileMode, "read, 4") === 5 // FileMode.read | FileMode.exclusive
+let E = (() => {
+  let E = Object.create(null), A, B, C;
+  Object.defineProperty(E, "A", { value: A = 1 });
+  Object.defineProperty(E, "B", { value: B = 2 });
+  Object.defineProperty(E, "C", { value: C = A | E.A });
+  Object.defineProperty(E, Symbol.iterator, {
+    value: function* () {
+      yield ["A", E.A];
+      yield ["B", E.B];
+      yield ["C", E.C];
+    }
+  });
+  Object.defineProperty(E, Symbol.toStringTag, { value: "E" });
+  Object.preventExtensions(E);
+  return E;
+})
 ```
 
-# Remarks
+# Other Considerations
 
-- Why default to Number?
-  - In prior discussions, there are some preferences for the use of 
-    [symbol values](https://esdiscuss.org/topic/propose-simpler-string-constant#content-8), 
-    while there are other preferences that include the use of 
-    [strings and numbers](https://esdiscuss.org/topic/propose-simpler-string-constant#content-14). 
-    This approach gives you the ability to support both scenarios through the optional `of` clause.
-  - The auto-increment behavior of enums in other languages is used fairly regularly. Auto-
-    increment is not viable if String or Symbol were the default type. 
-  - We could consider switching on auto-increment if the prior declaration was initialized with a
-    Number, but then you would have confusion over declarations like this:
+## `enum` Expressions
 
-    ```ts
-    enum Mixed {
-      first, // If this is a Symbol by default...
-      second = 1,
-      third // ...is this a Symbol or the Number `2`?
-    }
-    ```
+While ECMAScript has both statement and expression forms for `class` and `function` declarations, this proposal does not
+currently support `enum` expressions. There is no concept of an `enum` expression in TypeScript, though we may consider
+`enum` expressions for ECMAScript if there is sufficient motivation.
+
+## `export`/`export default`
+
+An `enum` declaration would support both `export` and `export default`, much like `class`.
+
+## Interaction with Shared Structs
+
+In general, this proposal hopes to align enum member values to those that can be shared with a `shared struct`, however
+it is important to note that a `Symbol`-valued enum that uses `Symbol()` and not `Symbol.for()` would produce values
+that cannot be reconciled between two Agents. In addition, ADT enums may need to contain non-shared data, such as in an
+`Option` or `Result` enum. As such, this proposal may seek to introduce a `shared enum` declaration that further
+restricts allowed inputs.
+
+# Differences from TypeScript
+
+There are several differences in the `enum` declaration for this proposal compared to TypeScript's `enum`:
+
+- [Auto-initializers](#auto-initializers)
+- [Declaration merging](#declaration-merging)
+- [Reverse mapping](#reverse-mapping)
+- [`const enum`](#const-enum)
+- [`Symbol` values](#symbol-values)
+- [`BigInt` values](#bigint-values)
+- [`export default`](#export-default)
+
+## Auto-Initializers
+
+TypeScript's `enum` supports auto-initialization of enum members:
+
+```ts
+enum Numbers {
+  zero, // 0
+  one,  // 1
+  two   // 2
+}
+```
+
+However, this behavior is contentious amongst some TC39 delegates and has been removed from this proposal. TypeScript
+will continue to support auto-initializiation due to its frequent use within the developer community, but would emit
+explicit initializers to JavaScript. It is possible that another form of auto-initializiation may be introduced in the
+future that could be utilized by both TypeScript and ECMAScript.
+
+## Declaration Merging
+
+TypeScript (as of v5.8) allows `enum` declarations to merge with other `enum` (and `namespace`) declarations with the
+same name. This is not a desirable feature for ECMAScript enums and will not be supported. TypeScript is considering
+[deprecating this feature](https://github.com/microsoft/TypeScript/issues/54500#issuecomment-2770170732) in
+TypeScript 6.0.
+
+## Reverse Mapping
+
+TypeScript currently supports reverse-mapping enum values back to enum member names using `E[value]`, but only for
+`Number` values. This limitation is intended to avoid collisions for `String`-valued enum members that could potentially
+overwrite other members. While this information is invaluable for debugging, diagnostics, formatting, and serialization,
+it is far less frequently used compared to `enum` on the whole.
+
+To avoid this inconsistency, we propose instead propose introducing reverse mapping by way of the `@@iterator` built-in
+symbol:
+
+```js
+enum E {
+  A = 0,
+  B = "A",
+}
+
+for (const [key, value] of E) {
+  console.log(`${key}: ${value}`);
+}
+
+// prints:
+//  A: 0
+//  B: A
+```
+
+If adopted, TypeScript would add support for `@@iterator` while eventually deprecating existing reverse mapping support.
+
+
+## `const enum`
+
+TypeScript supports the concept of a `const enum` declaration, which is similar to a normal `enum` declaration except
+that enum values are inlined into their use sites. As this capability requires whole program knowledge, it is not a
+feature we intend to support in ECMAScript enums.
+
+
+## `Symbol` values
+
+TypeScript does not currently support `Symbol` values for enums, but would add support if this feature were to be
+adopted.
+
+
+## `BigInt` values
+
+TypeScript does not currently support `BigInt` values for enums, but would add support if this feature were to be
+adopted.
+
+
+## `export default`
+
+TypeScript does not currently support `export default` on an enum, but would add support if this feature were to be
+adopted.
+
+
+# Future Directions
+
+While this proposal is intended to be rather limited in scope, there are several potential areas for future advancement
+in the form of follow-on proposals:
+
+- [Algebraic Data Types](#algebraic-data-types-adts)
+- [Decorators](#decorators)
+- [Auto-Initializers](#auto-initializers-1)
+
+## Algebraic Data Types (ADTs)
+
+Algebraic Data Types (ADT) are structured objects with some form of discriminant property. A future enhancement of an
+ECMAScript `enum` declaration might support ADT enums in conjunction with [Extractors][] and [Pattern Matching][]:
+
+```js
+enum Option {
+  Some(value),
+  None()
+}
+
+const opt = Option.Some(123);
+match (opt) {
+  Option.Some(let value): console.log(value);
+  Option.None(): console.log("<no value>");
+}
+
+
+enum Result {
+  Ok(value),
+  Error(reason)
+}
+
+function try_(cb) {
+  try {
+    return Result.Ok(_cb());
+  } catch (e) {
+    return Result.Error(e);
+  }
+}
+
+const res = try_(() => obj.doWork());
+match (res) {
+  Result.Ok(let value): ...;
+  Result.Error(let reason): ...;
+}
+```
+
+## Decorators
+
+In the future we may opt to extend support for [Decorators](https://github.com/tc39/proposal-decorators) to `enum`
+declarations to support serialization/deserialization, formatting, and FFI scenarios:
+
+```js
+enum Role {
+  @Alias(["user", "person"], { ignoreCase: true })
+  user = 1,
+  @Alias(["admin", "administrator"], { ignoreCase true })
+  admin = 2,
+}
+```
+
+## Auto-Initializers
+
+While this proposal does not support TypeScript's auto-initialization semantics, we may consider introducing an
+alternative syntax in a future proposal, such as the `of` clause described in an
+[older version of this proposal](https://github.com/rbuckton/proposal-enum/tree/old):
+
+```js
+enum Numbers of Number { zero, one, two, three }
+Numbers.zero; // 0
+```
+
+Or through some form of statically recognizable syntax:
+
+```js
+auto enum Numbers { zero, one, two, three }
+```
+
 
 # TODO
 
@@ -440,6 +425,8 @@ The following is a high-level list of tasks to progress through each stage of th
 
 * [Enums?](https://esdiscuss.org/topic/enums)
 * [Propose simpler string constant](https://esdiscuss.org/topic/propose-simpler-string-constant)
+* [Old version of this proposal](https://github.com/rbuckton/proposal-enum/tree/old)
+* [Prior `enum` proposal by Jack-Works](https://github.com/jack-works/proposal-enum)
 
 <!-- The following are shared links used throughout the README: -->
 
@@ -455,3 +442,7 @@ The following is a high-level list of tasks to progress through each stage of th
 [Implementation1]: #todo
 [Implementation2]: #todo
 [Ecma262PullRequest]: #todo
+[Enumerated Type]: https://en.wikipedia.org/wiki/Enumerated_type
+[TypeScript Type Stripping]: https://nodejs.org/docs/latest/api/typescript.html#type-stripping
+[Extractors]: https://github.com/tc39/proposal-extractors
+[Pattern Matching]: https://github.com/tc39/proposal-pattern-matching

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ for each member of the enum. These results are stored as properties of an _enum 
 _enum object_ is an ordinary object whose \[\[Prototype]] is `null`. Each enum member defines
 a property on the _enum object_.
 
-In addition, an _enum object_ contains an `@@iterator` method that yields a `[key, value]` entry for each declard enum
+In addition, an _enum object_ contains an `@@iterator` method that yields a `[key, value]` entry for each declared enum
 member, in document order. To explain the semantics of the `@@iterator` method, an _enum object_ may require an
 \[\[EnumMembers]] internal slot.
 


### PR DESCRIPTION
This updates this `enum` proposal to reflect a minimally viable version of an ECMAScript `enum` declaration based on TypeScript's `enum`.