### PR TITLE
chore: fix typo in readme code snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ enum Result {
 
 function try_(cb) {
   try {
-    return Result.Ok(_cb());
+    return Result.Ok(cb());
   } catch (e) {
     return Result.Error(e);
   }


### PR DESCRIPTION
The callback function “cb” seems to have a typo here. 